### PR TITLE
apply auto_ids to glossary terms

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -11,26 +11,65 @@ permalink: /reference/
 
 The following list captures terms that need to be added to this glossary. This is a great way to contribute.
 
-- [Accelerator](https://en.wikipedia.org/wiki/Hardware_acceleration)
-- [Beowulf cluster](https://en.wikipedia.org/wiki/Beowulf_cluster)
-- [Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit)
-- [Cloud computing](https://en.wikipedia.org/wiki/Cloud_computing)
-- [Cluster](https://en.wikipedia.org/wiki/Computer_cluster): a collection of computers configured to enable collaboration on a common task by
-  means of purposefully configured hardware (*e.g.*, networking) and software (*e.g.* workload
-  management).
-- [Distributed memory](https://en.wikipedia.org/wiki/Distributed_memory)
-- [Grid computing](https://en.wikipedia.org/wiki/Grid_computing)
-- [High availability computing](https://en.wikipedia.org/wiki/High_availability)
-- [High performance computing](https://en.wikipedia.org/w/index.php?title=High-performance_computing&redirect=no)
-- [Interconnect](https://en.wikipedia.org/wiki/Supercomputer_architecture)
-- [Node](https://en.wikipedia.org/wiki/Node_(computer_science))
-- [Parallel](https://en.wikipedia.org/wiki/Parallel_computing)
-- [Serial](https://en.wikipedia.org/wiki/Serial_computer)
-- [Server](https://en.wikipedia.org/wiki/Server_(computing))
-- [Shared memory](https://en.wikipedia.org/wiki/Shared_memory)
-- [Slurm](https://en.wikipedia.org/wiki/Slurm_Workload_Manager)
-- [Supercomputer](https://en.wikipedia.org/wiki/Supercomputer) -- "[a major scientific instrument](https://www.hpcnotes.com/2015/10/essential-analogies-for-hpc-advocate.html)"
-- [Workstation](https://en.wikipedia.org/wiki/Workstation)
-- [Grid Engine](https://en.wikipedia.org/wiki/Oracle_Grid_Engine)
-- [Parallel File System](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems)
+{:auto_ids}
+[Accelerator](https://en.wikipedia.org/wiki/Hardware_acceleration)
+:    *to be defined*
 
+[Beowulf cluster](https://en.wikipedia.org/wiki/Beowulf_cluster)
+:    *to be defined*
+
+[Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit)
+:    *to be defined*
+
+[Cloud computing](https://en.wikipedia.org/wiki/Cloud_computing)
+:    *to be defined*
+
+[Cluster](https://en.wikipedia.org/wiki/Computer_cluster)
+:     a collection of computers configured to enable collaboration on a common task by
+      means of purposefully configured hardware (*e.g.*, networking) and software (*e.g.* workload
+      management).
+
+[Distributed memory](https://en.wikipedia.org/wiki/Distributed_memory)
+:    *to be defined*
+
+[Grid computing](https://en.wikipedia.org/wiki/Grid_computing)
+:    *to be defined*
+
+[High availability computing](https://en.wikipedia.org/wiki/High_availability)
+:    *to be defined*
+
+[High performance computing](https://en.wikipedia.org/w/index.php?title=High-performance_computing&redirect=no)
+:    *to be defined*
+
+[Interconnect](https://en.wikipedia.org/wiki/Supercomputer_architecture)
+:    *to be defined*
+
+[Node](https://en.wikipedia.org/wiki/Node_(computer_science))
+:    *to be defined*
+
+[Parallel](https://en.wikipedia.org/wiki/Parallel_computing)
+:    *to be defined*
+
+[Serial](https://en.wikipedia.org/wiki/Serial_computer)
+:    *to be defined*
+
+[Server](https://en.wikipedia.org/wiki/Server_(computing))
+:    *to be defined*
+
+[Shared memory](https://en.wikipedia.org/wiki/Shared_memory)
+:    *to be defined*
+
+[Slurm](https://en.wikipedia.org/wiki/Slurm_Workload_Manager)
+:    *to be defined*
+
+[Supercomputer](https://en.wikipedia.org/wiki/Supercomputer)
+:    ... "[a major scientific instrument](https://www.hpcnotes.com/2015/10/essential-analogies-for-hpc-advocate.html)" ...
+
+[Workstation](https://en.wikipedia.org/wiki/Workstation)
+:    *to be defined*
+
+[Grid Engine](https://en.wikipedia.org/wiki/Oracle_Grid_Engine)
+:    *to be defined*
+
+[Parallel File System](https://en.wikipedia.org/wiki/Clustered_file_system#Distributed_file_systems)
+:    *to be defined*


### PR DESCRIPTION
Addresses my [comment](https://github.com/hpc-carpentry/hpc-intro/pull/38#issuecomment-421414662).
Makes glossary entries directly linkable, *e.g.*

```
[AMOS](https://www.top500.org/system/177735) is ranked 330th
of the top 500 [supercomputers]({{ site.url }}/reference.html/#supercomputer).
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/psteinb/hpc-intro/1)
<!-- Reviewable:end -->
